### PR TITLE
Fix composite iterators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ide
+.vscode

--- a/behaviours.go
+++ b/behaviours.go
@@ -32,3 +32,21 @@ func (n *RunningBehaviour) Update() Status {
 	return Running
 }
 func (n *RunningBehaviour) Terminate() {}
+
+// XThenY
+type XThenY struct {
+	node
+
+	accessed bool
+	X, Y     Status
+}
+
+func (n *XThenY) Initialize() {}
+func (n *XThenY) Update() Status {
+	if n.accessed {
+		return n.Y
+	}
+	n.accessed = true
+	return n.X
+}
+func (n *XThenY) Terminate() {}

--- a/composite.go
+++ b/composite.go
@@ -16,6 +16,8 @@ type Composite interface {
 }
 
 type composite struct {
+	*node
+
 	// Golang has no Set structure, so use a map to mimic one
 	children map[Behaviour]struct{}
 }
@@ -53,9 +55,12 @@ func (n *composite) AddChild(child Behaviour) {
 }
 
 func (n *composite) RemoveChild(child Behaviour) {
+	// ensure that the node is re-initialized on next tick
+	n.state = Aborted
 	delete(n.children, child)
 }
 
 func (n *composite) ClearChildren() {
+	n.state = Aborted
 	n.children = make(map[Behaviour]struct{})
 }

--- a/composite.go
+++ b/composite.go
@@ -1,7 +1,15 @@
 package goedbt
 
+import (
+	"iter"
+)
+
+type next func()
+
 type Composite interface {
-	Children() []Behaviour
+	Behaviour
+
+	Children() (iter.Seq[Behaviour], next)
 	AddChild(child Behaviour)
 	RemoveChild(child Behaviour)
 	ClearChildren()
@@ -12,8 +20,32 @@ type composite struct {
 	children map[Behaviour]struct{}
 }
 
-func (n *composite) Children() []Behaviour {
-	return Keys(n.children)
+func (n *composite) Children() (iter.Seq[Behaviour], next) {
+	// copy the children map keys to a list so that modifications to it
+	// while we hold an active iterator don't affect iteration. use a list
+	// so that we can replay the same keys if needed
+	cc := make([]Behaviour, len(n.children))
+
+	var i int
+	for k := range n.children {
+		cc[i] = k
+		i += 1
+	}
+
+	i = 0
+
+	// return an iterator and a closure that increments the iterator so that we
+	// can resume iteration from the same key if a child is running
+	return func(yield func(Behaviour) bool) {
+		for {
+			if i >= len(cc) {
+				return
+			}
+			if !yield(cc[i]) {
+				return
+			}
+		}
+	}, func() { i += 1 }
 }
 
 func (n *composite) AddChild(child Behaviour) {

--- a/parallel.go
+++ b/parallel.go
@@ -8,14 +8,13 @@ import (
 // concurrently. Returns Running until at least one child succeeds.
 // If all children fail, returns Failure.
 type Parallel struct {
-	*node
 	*composite
 }
 
 func NewParallel() *Parallel {
 	return &Parallel{
-		node: &node{state: Invalid},
 		composite: &composite{
+			node:     &node{state: Invalid},
 			children: make(map[Behaviour]struct{}),
 		},
 	}

--- a/selector.go
+++ b/selector.go
@@ -1,10 +1,17 @@
 package goedbt
 
+import (
+	"iter"
+)
+
 // Selector defines a Behaviour BehaviourNode that checks each of its children,
 // returning the first non-Failure status or Failure if all children fail
 type Selector struct {
 	*node
 	*composite
+
+	seq  iter.Seq[Behaviour]
+	next func()
 }
 
 func NewSelector() *Selector {
@@ -16,17 +23,22 @@ func NewSelector() *Selector {
 	}
 }
 
-func (n *Selector) Initialize() {}
-func (n *Selector) Terminate()  {}
+func (n *Selector) Initialize() {
+	n.seq, n.next = n.Children()
+}
 
 func (n *Selector) Update() Status {
-	for c := range n.children {
-		if status := tick(c); status != Failure {
+	for c := range n.seq {
+		status := tick(c)
+		if status != Failure {
 			n.state = status
 			return n.state
 		}
+		n.next()
 	}
 
 	n.state = Failure
 	return n.state
 }
+
+func (n *Selector) Terminate() {}

--- a/selector.go
+++ b/selector.go
@@ -7,7 +7,6 @@ import (
 // Selector defines a Behaviour BehaviourNode that checks each of its children,
 // returning the first non-Failure status or Failure if all children fail
 type Selector struct {
-	*node
 	*composite
 
 	seq  iter.Seq[Behaviour]
@@ -16,8 +15,8 @@ type Selector struct {
 
 func NewSelector() *Selector {
 	return &Selector{
-		node: &node{state: Invalid},
 		composite: &composite{
+			node:     &node{state: Invalid},
 			children: make(map[Behaviour]struct{}),
 		},
 	}

--- a/sequencer.go
+++ b/sequencer.go
@@ -5,7 +5,6 @@ import "iter"
 // Sequencer defines a Behaviour BehaviourNode that checks each of its children,
 // returning the first non-Success status or Success if all children succeed
 type Sequencer struct {
-	*node
 	*composite
 
 	seq  iter.Seq[Behaviour]
@@ -14,8 +13,8 @@ type Sequencer struct {
 
 func NewSequencer() *Sequencer {
 	return &Sequencer{
-		node: &node{state: Invalid},
 		composite: &composite{
+			node:     &node{state: Invalid},
 			children: make(map[Behaviour]struct{}),
 		},
 	}

--- a/sequencer.go
+++ b/sequencer.go
@@ -1,10 +1,15 @@
 package goedbt
 
+import "iter"
+
 // Sequencer defines a Behaviour BehaviourNode that checks each of its children,
 // returning the first non-Success status or Success if all children succeed
 type Sequencer struct {
 	*node
 	*composite
+
+	seq  iter.Seq[Behaviour]
+	next func()
 }
 
 func NewSequencer() *Sequencer {
@@ -16,17 +21,21 @@ func NewSequencer() *Sequencer {
 	}
 }
 
-func (n *Sequencer) Initialize() {}
-func (n *Sequencer) Terminate()  {}
+func (n *Sequencer) Initialize() {
+	n.seq, n.next = n.Children()
+}
 
 func (n *Sequencer) Update() Status {
-	for c := range n.children {
+	for c := range n.seq {
 		if status := tick(c); status != Success {
 			n.state = status
 			return n.state
 		}
+		n.next()
 	}
 
 	n.state = Success
 	return n.state
 }
+
+func (n *Sequencer) Terminate() {}

--- a/sequencer_test.go
+++ b/sequencer_test.go
@@ -6,19 +6,51 @@ import (
 	goedbt "github.com/dpsommer/go-edbt"
 )
 
-func TestSequencer(t *testing.T) {
-	sequencer := goedbt.NewSequencer()
-	sequencer.AddChild(&goedbt.SuccessBehaviour{})
-	tree := goedbt.NewBehaviourTree(sequencer)
-
-	status := goedbt.Tick(tree.Root)
-	if status != goedbt.Success {
-		t.Errorf("Sequencer got %d, want %d", status, goedbt.Success)
+func setupCompositeTree(c goedbt.Composite, tasks ...goedbt.Behaviour) *goedbt.BehaviourTree {
+	for _, t := range tasks {
+		c.AddChild(t)
 	}
 
-	sequencer.AddChild(&goedbt.FailureBehaviour{})
-	status = goedbt.Tick(tree.Root)
-	if status != goedbt.Failure {
-		t.Errorf("Sequencer got %d, want %d", status, goedbt.Failure)
+	return goedbt.NewBehaviourTree(c)
+}
+
+func TestSequencer(t *testing.T) {
+	tt := map[string]struct {
+		behaviours []goedbt.Behaviour
+		expected   []goedbt.Status
+	}{
+		"returns success then failure": {
+			behaviours: []goedbt.Behaviour{
+				&goedbt.XThenY{X: goedbt.Success, Y: goedbt.Failure},
+			},
+			expected: []goedbt.Status{goedbt.Success, goedbt.Failure},
+		},
+		"returns running": {
+			behaviours: []goedbt.Behaviour{
+				&goedbt.SuccessBehaviour{},
+				&goedbt.RunningBehaviour{},
+			},
+			expected: []goedbt.Status{goedbt.Running},
+		},
+		"returns running then success": {
+			behaviours: []goedbt.Behaviour{
+				&goedbt.SuccessBehaviour{},
+				&goedbt.XThenY{X: goedbt.Running, Y: goedbt.Success},
+			},
+			expected: []goedbt.Status{goedbt.Running, goedbt.Success},
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			tree := setupCompositeTree(goedbt.NewSequencer(), tc.behaviours...)
+
+			for _, s := range tc.expected {
+				status := goedbt.Tick(tree.Root)
+				if status != s {
+					t.Errorf("Selector got %d, want %d", status, s)
+				}
+			}
+		})
 	}
 }

--- a/status.go
+++ b/status.go
@@ -7,4 +7,5 @@ const (
 	Success
 	Failure
 	Running
+	Aborted
 )

--- a/status.go
+++ b/status.go
@@ -3,8 +3,8 @@ package goedbt
 type Status int
 
 const (
-	Invalid Status = -1
-	Success Status = iota
+	Invalid Status = iota - 1
+	Success
 	Failure
 	Running
 )


### PR DESCRIPTION
* [Fix sequencer and selector iteration](https://github.com/dpsommer/go-edbt/commit/d60bbe94641d784cf9bbc217529723a178500eab)
  * Previously, selectors and sequencers would tick over each
 child on each received tick; this implementation meant that
 if a Running state was returned from an nth child, future
 ticks could return erroneous states by re-ticking a child
 that was already checked
  * This change modifies the behaviour of selectors and sequencers
 by including a call to Children in the Initialize function
  * Children now returns an iterator seq and a closure next that
 allow the caller to hold positional iteration and resume on
 subsequent ticks if a Running state is returned
  * If a non-Running state is returned, Initialize will be called,
 resetting the iterator
  * Each instantiation of the iterator creates a copy of the current
 set of children to avoid issues upon future modification

* [Add Aborted state](https://github.com/dpsommer/go-edbt/commit/b28f2f0871e8aab1edc0101569e209369d7555dc) 
  * Move node embedding to composite struct
  * Set composite node state to aborted if children are removed at
 runtime