### PR TITLE
Refactor Children iter as custom iterator type

### DIFF
--- a/selector.go
+++ b/selector.go
@@ -1,16 +1,11 @@
 package goedbt
 
-import (
-	"iter"
-)
-
 // Selector defines a Behaviour BehaviourNode that checks each of its children,
 // returning the first non-Failure status or Failure if all children fail
 type Selector struct {
 	*composite
 
-	seq iter.Seq[Behaviour]
-	next
+	iterator[Behaviour]
 }
 
 func NewSelector() *Selector {
@@ -23,7 +18,7 @@ func NewSelector() *Selector {
 }
 
 func (n *Selector) Initialize() {
-	n.seq, n.next = n.Children()
+	n.iterator = n.Children()
 }
 
 func (n *Selector) Update() Status {

--- a/sequencer.go
+++ b/sequencer.go
@@ -1,14 +1,11 @@
 package goedbt
 
-import "iter"
-
 // Sequencer defines a Behaviour BehaviourNode that checks each of its children,
 // returning the first non-Success status or Success if all children succeed
 type Sequencer struct {
 	*composite
 
-	seq iter.Seq[Behaviour]
-	next
+	iterator[Behaviour]
 }
 
 func NewSequencer() *Sequencer {
@@ -21,7 +18,7 @@ func NewSequencer() *Sequencer {
 }
 
 func (n *Sequencer) Initialize() {
-	n.seq, n.next = n.Children()
+	n.iterator = n.Children()
 }
 
 func (n *Sequencer) Update() Status {

--- a/utils.go
+++ b/utils.go
@@ -1,5 +1,12 @@
 package goedbt
 
+import "iter"
+
+type iterator[T any] struct {
+	seq iter.Seq[T]
+	next
+}
+
 type Set[K comparable] map[K]struct{}
 
 func keys[K comparable, T any](m map[K]T) []K {
@@ -14,6 +21,6 @@ func keys[K comparable, T any](m map[K]T) []K {
 	return keys
 }
 
-func pop[K any](s []K) (K, []K) {
+func pop[T any](s []T) (T, []T) {
 	return s[len(s)-1], s[:len(s)-1]
 }


### PR DESCRIPTION
Improve clarity by wrapping iter and next functions as custom iterator type.