### PR TITLE
Event-driven Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # ide
 .vscode
+
+# other
+local/

--- a/README.md
+++ b/README.md
@@ -1,23 +1,26 @@
 ## Interface
 
-The interface we want to define:
+The interface we want to define (based on [Agis et al., 2020](https://www.sciencedirect.com/science/article/abs/pii/S0957417420302815) and [Champandard and Dunstan, 2012](https://www.gameaipro.com/GameAIPro/GameAIPro_Chapter06_The_Behavior_Tree_Starter_Kit.pdf)):
 
 
 * EDBT -> root component, setup a behaviour tree
 * Nodes -> each behaviour node.
     * Composite nodes
-        * Selector (OR behaviour)
-        * Sequencer (AND behaviour)
-        * Parallel (concurrent behaviour)
+        * [x] Selector (OR behaviour)
+        * [x] Sequencer (AND behaviour)
+        * [x] Parallel (concurrent behaviour)
+        * [ ] Filter/preconditions?
+        * [ ] Monitor?
+        * [ ] Active selector?
     * Decorators (decorate tasks)
-        * BOD - blackboard observer decorator
-        * Conditional?
-        * Inversion?
-    * Coordination
-        * Request Handler
-        * Soft Message Sender
-        * Hard Message Sender
+        * [ ] BOD - blackboard observer decorator
+        * [ ] Conditional?
+        * [ ] Inversion?
     * Event-driven
-        * ?
+        * [ ] ?
+    * Coordination
+        * [ ] Request Handler
+        * [ ] Soft Message Sender
+        * [ ] Hard Message Sender
     * Tasks
-        * Abstract behaviours
+        * [ ] Abstract behaviours

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 The interface we want to define (based on [Agis et al., 2020](https://www.sciencedirect.com/science/article/abs/pii/S0957417420302815) and [Champandard and Dunstan, 2012](https://www.gameaipro.com/GameAIPro/GameAIPro_Chapter06_The_Behavior_Tree_Starter_Kit.pdf)):
 
 
-* EDBT -> root component, setup a behaviour tree
-* Nodes -> each behaviour node.
+* [x] BehaviourTree -> root component, setup a behaviour tree
+* [ ] Behaviour nodes ->
     * Composite nodes
         * [x] Selector (OR behaviour)
         * [x] Sequencer (AND behaviour)
@@ -17,7 +17,10 @@ The interface we want to define (based on [Agis et al., 2020](https://www.scienc
         * [ ] Conditional?
         * [ ] Inversion?
     * Event-driven
-        * [ ] ?
+        * [x] BehaviourTree
+        * [ ] Selector
+        * [x] Sequencer
+        * [ ] Parallel
     * Coordination
         * [ ] Request Handler
         * [ ] Soft Message Sender

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The interface we want to define (based on [Agis et al., 2020](https://www.scienc
         * [ ] Inversion?
     * Event-driven
         * [x] BehaviourTree
-        * [ ] Selector
+        * [x] Selector
         * [x] Sequencer
-        * [ ] Parallel
+        * [x] Parallel
     * Coordination
         * [ ] Request Handler
         * [ ] Soft Message Sender

--- a/behaviour.go
+++ b/behaviour.go
@@ -1,18 +1,28 @@
 package goedbt
 
+type Observer func(s Status)
+
 type Behaviour interface {
 	State() Status
+	SetState(s Status)
+
 	Initialize()
 	Update() Status
 	Teardown()
 	Abort()
+
+	FireObserver(s Status)
 }
 
-type node struct {
+type behaviour struct {
 	state Status
+
+	Observer
 }
 
-func (n *node) State() Status { return n.state }
+func (n *behaviour) State() Status         { return n.state }
+func (n *behaviour) SetState(s Status)     { n.state = s }
+func (n *behaviour) FireObserver(s Status) { n.Observer(s) }
 
 func tick(b Behaviour) Status {
 	if b.State() != Running {

--- a/behaviour.go
+++ b/behaviour.go
@@ -1,37 +1,32 @@
 package goedbt
 
-type Observer func(s Status)
-
 type Behaviour interface {
 	State() Status
 	SetState(s Status)
 
-	Initialize()
-	Update() Status
-	Teardown()
-	Abort()
-
-	FireObserver(s Status)
+	initialize()
+	update() Status
+	teardown()
+	abort()
 }
 
 type behaviour struct {
 	state Status
-
-	Observer
 }
 
-func (n *behaviour) State() Status         { return n.state }
-func (n *behaviour) SetState(s Status)     { n.state = s }
-func (n *behaviour) FireObserver(s Status) { n.Observer(s) }
+func (n *behaviour) State() Status { return n.state }
+func (n *behaviour) SetState(s Status) {
+	n.state = s
+}
 
 func tick(b Behaviour) Status {
 	if b.State() != Running {
-		b.Initialize()
+		b.initialize()
 	}
 
-	state := b.Update()
+	state := b.update()
 	if state != Running {
-		b.Teardown()
+		b.teardown()
 	}
 
 	return state

--- a/behaviour.go
+++ b/behaviour.go
@@ -25,6 +25,8 @@ func tick(b Behaviour) Status {
 	}
 
 	state := b.update()
+	b.SetState(state)
+
 	if state != Running {
 		b.teardown()
 	}

--- a/behaviours.go
+++ b/behaviours.go
@@ -2,7 +2,7 @@ package goedbt
 
 // SuccessBehaviour
 type SuccessBehaviour struct {
-	node
+	behaviour
 }
 
 func (n *SuccessBehaviour) Initialize() {}
@@ -14,7 +14,7 @@ func (n *SuccessBehaviour) Abort()    {}
 
 // FailureBehaviour
 type FailureBehaviour struct {
-	node
+	behaviour
 }
 
 func (n *FailureBehaviour) Initialize() {}
@@ -26,7 +26,7 @@ func (n *FailureBehaviour) Abort()    {}
 
 // RunningBehaviour
 type RunningBehaviour struct {
-	node
+	behaviour
 }
 
 func (n *RunningBehaviour) Initialize() {}
@@ -38,7 +38,7 @@ func (n *RunningBehaviour) Abort()    {}
 
 // XThenY
 type XThenY struct {
-	node
+	behaviour
 
 	accessed bool
 	X, Y     Status

--- a/behaviours.go
+++ b/behaviours.go
@@ -5,8 +5,8 @@ type SuccessBehaviour struct {
 	behaviour
 }
 
-func (n *SuccessBehaviour) initialize()    { n.state = Success }
-func (n *SuccessBehaviour) update() Status { return n.state }
+func (n *SuccessBehaviour) initialize()    {}
+func (n *SuccessBehaviour) update() Status { return Success }
 func (n *SuccessBehaviour) teardown()      {}
 func (n *SuccessBehaviour) abort()         {}
 
@@ -15,8 +15,8 @@ type FailureBehaviour struct {
 	behaviour
 }
 
-func (n *FailureBehaviour) initialize()    { n.state = Failure }
-func (n *FailureBehaviour) update() Status { return n.state }
+func (n *FailureBehaviour) initialize()    {}
+func (n *FailureBehaviour) update() Status { return Failure }
 func (n *FailureBehaviour) teardown()      {}
 func (n *FailureBehaviour) abort()         {}
 
@@ -25,8 +25,8 @@ type RunningBehaviour struct {
 	behaviour
 }
 
-func (n *RunningBehaviour) initialize()    { n.state = Running }
-func (n *RunningBehaviour) update() Status { return n.state }
+func (n *RunningBehaviour) initialize()    {}
+func (n *RunningBehaviour) update() Status { return Running }
 func (n *RunningBehaviour) teardown()      {}
 func (n *RunningBehaviour) abort()         {}
 

--- a/behaviours.go
+++ b/behaviours.go
@@ -5,36 +5,30 @@ type SuccessBehaviour struct {
 	behaviour
 }
 
-func (n *SuccessBehaviour) initialize() { n.state = Success }
-func (n *SuccessBehaviour) update() Status {
-	return Success
-}
-func (n *SuccessBehaviour) teardown() {}
-func (n *SuccessBehaviour) abort()    {}
+func (n *SuccessBehaviour) initialize()    { n.state = Success }
+func (n *SuccessBehaviour) update() Status { return n.state }
+func (n *SuccessBehaviour) teardown()      {}
+func (n *SuccessBehaviour) abort()         {}
 
 // FailureBehaviour
 type FailureBehaviour struct {
 	behaviour
 }
 
-func (n *FailureBehaviour) initialize() { n.state = Failure }
-func (n *FailureBehaviour) update() Status {
-	return Failure
-}
-func (n *FailureBehaviour) teardown() {}
-func (n *FailureBehaviour) abort()    {}
+func (n *FailureBehaviour) initialize()    { n.state = Failure }
+func (n *FailureBehaviour) update() Status { return n.state }
+func (n *FailureBehaviour) teardown()      {}
+func (n *FailureBehaviour) abort()         {}
 
 // RunningBehaviour
 type RunningBehaviour struct {
 	behaviour
 }
 
-func (n *RunningBehaviour) initialize() { n.state = Running }
-func (n *RunningBehaviour) update() Status {
-	return Running
-}
-func (n *RunningBehaviour) teardown() {}
-func (n *RunningBehaviour) abort()    {}
+func (n *RunningBehaviour) initialize()    { n.state = Running }
+func (n *RunningBehaviour) update() Status { return n.state }
+func (n *RunningBehaviour) teardown()      {}
+func (n *RunningBehaviour) abort()         {}
 
 // XThenY
 type XThenY struct {

--- a/behaviours.go
+++ b/behaviours.go
@@ -5,36 +5,36 @@ type SuccessBehaviour struct {
 	behaviour
 }
 
-func (n *SuccessBehaviour) Initialize() {}
-func (n *SuccessBehaviour) Update() Status {
+func (n *SuccessBehaviour) initialize() { n.state = Success }
+func (n *SuccessBehaviour) update() Status {
 	return Success
 }
-func (n *SuccessBehaviour) Teardown() {}
-func (n *SuccessBehaviour) Abort()    {}
+func (n *SuccessBehaviour) teardown() {}
+func (n *SuccessBehaviour) abort()    {}
 
 // FailureBehaviour
 type FailureBehaviour struct {
 	behaviour
 }
 
-func (n *FailureBehaviour) Initialize() {}
-func (n *FailureBehaviour) Update() Status {
+func (n *FailureBehaviour) initialize() { n.state = Failure }
+func (n *FailureBehaviour) update() Status {
 	return Failure
 }
-func (n *FailureBehaviour) Teardown() {}
-func (n *FailureBehaviour) Abort()    {}
+func (n *FailureBehaviour) teardown() {}
+func (n *FailureBehaviour) abort()    {}
 
 // RunningBehaviour
 type RunningBehaviour struct {
 	behaviour
 }
 
-func (n *RunningBehaviour) Initialize() {}
-func (n *RunningBehaviour) Update() Status {
+func (n *RunningBehaviour) initialize() { n.state = Running }
+func (n *RunningBehaviour) update() Status {
 	return Running
 }
-func (n *RunningBehaviour) Teardown() {}
-func (n *RunningBehaviour) Abort()    {}
+func (n *RunningBehaviour) teardown() {}
+func (n *RunningBehaviour) abort()    {}
 
 // XThenY
 type XThenY struct {
@@ -44,13 +44,14 @@ type XThenY struct {
 	X, Y     Status
 }
 
-func (n *XThenY) Initialize() {}
-func (n *XThenY) Update() Status {
+func (n *XThenY) initialize() { n.state = n.X }
+func (n *XThenY) update() Status {
 	if n.accessed {
+		n.state = n.Y
 		return n.Y
 	}
 	n.accessed = true
 	return n.X
 }
-func (n *XThenY) Teardown() {}
-func (n *XThenY) Abort()    {}
+func (n *XThenY) teardown() {}
+func (n *XThenY) abort()    {}

--- a/composite.go
+++ b/composite.go
@@ -12,7 +12,7 @@ type Composite interface {
 }
 
 type composite struct {
-	*node
+	*behaviour
 
 	children Set[Behaviour]
 }

--- a/composite.go
+++ b/composite.go
@@ -1,7 +1,5 @@
 package goedbt
 
-type next func()
-
 type Composite interface {
 	Behaviour
 
@@ -22,24 +20,7 @@ func (n *composite) Children() iterator[Behaviour] {
 	// while we hold an active iterator don't affect iteration. use a list
 	// so that we can replay the same keys if needed
 	cc := keys(n.children)
-
-	var i int
-
-	// return an iterator and a closure that increments the iterator so that we
-	// can resume iteration from the same key if a child is running
-	return iterator[Behaviour]{
-		seq: func(yield func(Behaviour) bool) {
-			for {
-				if i >= len(cc) {
-					return
-				}
-				if !yield(cc[i]) {
-					return
-				}
-			}
-		},
-		next: func() { i += 1 },
-	}
+	return newIterator(cc)
 }
 
 func (n *composite) AddChild(child Behaviour) {

--- a/composite.go
+++ b/composite.go
@@ -14,7 +14,6 @@ type Composite interface {
 type composite struct {
 	*node
 
-	// Golang has no Set structure, so use a map to mimic one
 	children Set[Behaviour]
 }
 
@@ -29,7 +28,7 @@ func (n *composite) Children() iterator[Behaviour] {
 	// return an iterator and a closure that increments the iterator so that we
 	// can resume iteration from the same key if a child is running
 	return iterator[Behaviour]{
-		func(yield func(Behaviour) bool) {
+		seq: func(yield func(Behaviour) bool) {
 			for {
 				if i >= len(cc) {
 					return
@@ -39,7 +38,7 @@ func (n *composite) Children() iterator[Behaviour] {
 				}
 			}
 		},
-		func() { i += 1 },
+		next: func() { i += 1 },
 	}
 }
 

--- a/composite.go
+++ b/composite.go
@@ -12,6 +12,7 @@ type Composite interface {
 type composite struct {
 	*behaviour
 
+	tree     *BehaviourTree
 	children Set[Behaviour]
 }
 

--- a/deque.go
+++ b/deque.go
@@ -9,9 +9,9 @@ import "sync"
 // for bitwise modulus: x % n == x & (n - 1).
 const minCapacity = 4
 
-// Deque represents a single instance of the deque data structure. A Deque
+// deque represents a single instance of the deque data structure. A deque
 // instance contains items of the type specified by the type argument.
-type Deque[T any] struct {
+type deque[T any] struct {
 	buf    []T
 	head   int
 	tail   int
@@ -21,20 +21,8 @@ type Deque[T any] struct {
 	sync.Mutex
 }
 
-func NewDeque[T any](baseCap int) *Deque[T] {
-	minCap := minCapacity
-	// round baseCap up to the nearest power of 2
-	for minCap < baseCap {
-		minCap <<= 1
-	}
-
-	return &Deque[T]{
-		minCap: minCap,
-	}
-}
-
-// Cap returns the current capacity of the Deque. If q is nil, q.Cap() is zero.
-func (q *Deque[T]) Cap() int {
+// Cap returns the current capacity of the deque. If q is nil, q.Cap() is zero.
+func (q *deque[T]) Cap() int {
 	if q == nil {
 		return 0
 	}
@@ -43,7 +31,7 @@ func (q *Deque[T]) Cap() int {
 
 // Len returns the number of elements currently stored in the queue. If q is
 // nil, q.Len() returns zero.
-func (q *Deque[T]) Len() int {
+func (q *deque[T]) Len() int {
 	if q == nil {
 		return 0
 	}
@@ -53,7 +41,7 @@ func (q *Deque[T]) Len() int {
 // PushBack appends an element to the back of the queue. Implements FIFO when
 // elements are removed with PopFront, and LIFO when elements are removed with
 // PopBack.
-func (q *Deque[T]) PushBack(elem T) {
+func (q *deque[T]) PushBack(elem T) {
 	q.Lock()
 	defer q.Unlock()
 
@@ -66,7 +54,7 @@ func (q *Deque[T]) PushBack(elem T) {
 }
 
 // PushFront prepends an element to the front of the queue.
-func (q *Deque[T]) PushFront(elem T) {
+func (q *deque[T]) PushFront(elem T) {
 	q.Lock()
 	defer q.Unlock()
 
@@ -81,7 +69,7 @@ func (q *Deque[T]) PushFront(elem T) {
 // PopFront removes and returns the element from the front of the queue.
 // Implements FIFO when used with PushBack. If the queue is empty, the call
 // panics.
-func (q *Deque[T]) PopFront() T {
+func (q *deque[T]) PopFront() T {
 	q.Lock()
 	defer q.Unlock()
 
@@ -102,7 +90,7 @@ func (q *Deque[T]) PopFront() T {
 // PopBack removes and returns the element from the back of the queue.
 // Implements LIFO when used with PushBack. If the queue is empty, the call
 // panics.
-func (q *Deque[T]) PopBack() T {
+func (q *deque[T]) PopBack() T {
 	q.Lock()
 	defer q.Unlock()
 
@@ -125,7 +113,7 @@ func (q *Deque[T]) PopBack() T {
 
 // Front returns the element at the front of the queue. This is the element
 // that would be returned by PopFront. This call panics if the queue is empty.
-func (q *Deque[T]) Front() T {
+func (q *deque[T]) Front() T {
 	q.Lock()
 	defer q.Unlock()
 
@@ -137,7 +125,7 @@ func (q *Deque[T]) Front() T {
 
 // Back returns the element at the back of the queue. This is the element that
 // would be returned by PopBack. This call panics if the queue is empty.
-func (q *Deque[T]) Back() T {
+func (q *deque[T]) Back() T {
 	q.Lock()
 	defer q.Unlock()
 
@@ -152,7 +140,7 @@ func (q *Deque[T]) Back() T {
 // GC during reuse. The queue will not be resized smaller as long as items are
 // only added. Only when items are removed is the queue subject to getting
 // resized smaller.
-func (q *Deque[T]) Clear() {
+func (q *deque[T]) Clear() {
 	q.Lock()
 	defer q.Unlock()
 
@@ -168,17 +156,17 @@ func (q *Deque[T]) Clear() {
 }
 
 // prev returns the previous buffer position wrapping around buffer.
-func (q *Deque[T]) prev(i int) int {
+func (q *deque[T]) prev(i int) int {
 	return (i - 1) & (len(q.buf) - 1) // bitwise modulus
 }
 
 // next returns the next buffer position wrapping around buffer.
-func (q *Deque[T]) next(i int) int {
+func (q *deque[T]) next(i int) int {
 	return (i + 1) & (len(q.buf) - 1) // bitwise modulus
 }
 
 // growIfFull resizes up if the buffer is full.
-func (q *Deque[T]) growIfFull() {
+func (q *deque[T]) growIfFull() {
 	if q.count != len(q.buf) {
 		return
 	}
@@ -193,7 +181,7 @@ func (q *Deque[T]) growIfFull() {
 }
 
 // shrinkIfExcess resize down if the buffer 1/4 full.
-func (q *Deque[T]) shrinkIfExcess() {
+func (q *deque[T]) shrinkIfExcess() {
 	if len(q.buf) > q.minCap && (q.count<<2) == len(q.buf) {
 		q.resize(q.count << 1)
 	}
@@ -202,7 +190,7 @@ func (q *Deque[T]) shrinkIfExcess() {
 // resize resizes the deque to fit exactly twice its current contents. This is
 // used to grow the queue when it is full, and also to shrink it when it is
 // only a quarter full.
-func (q *Deque[T]) resize(newSize int) {
+func (q *deque[T]) resize(newSize int) {
 	newBuf := make([]T, newSize)
 	if q.tail > q.head {
 		copy(newBuf, q.buf[q.head:q.tail])

--- a/deque.go
+++ b/deque.go
@@ -1,0 +1,217 @@
+package goedbt
+
+import "sync"
+
+// modified version of https://github.com/gammazero/deque for use in the
+// event-driven BT implementation. adds mutex for concurrent access
+
+// minCapacity is the smallest capacity that deque may have. Must be power of 2
+// for bitwise modulus: x % n == x & (n - 1).
+const minCapacity = 4
+
+// Deque represents a single instance of the deque data structure. A Deque
+// instance contains items of the type specified by the type argument.
+type Deque[T any] struct {
+	buf    []T
+	head   int
+	tail   int
+	count  int
+	minCap int
+
+	sync.Mutex
+}
+
+func NewDeque[T any](baseCap int) *Deque[T] {
+	minCap := minCapacity
+	// round baseCap up to the nearest power of 2
+	for minCap < baseCap {
+		minCap <<= 1
+	}
+
+	return &Deque[T]{
+		minCap: minCap,
+	}
+}
+
+// Cap returns the current capacity of the Deque. If q is nil, q.Cap() is zero.
+func (q *Deque[T]) Cap() int {
+	if q == nil {
+		return 0
+	}
+	return len(q.buf)
+}
+
+// Len returns the number of elements currently stored in the queue. If q is
+// nil, q.Len() returns zero.
+func (q *Deque[T]) Len() int {
+	if q == nil {
+		return 0
+	}
+	return q.count
+}
+
+// PushBack appends an element to the back of the queue. Implements FIFO when
+// elements are removed with PopFront, and LIFO when elements are removed with
+// PopBack.
+func (q *Deque[T]) PushBack(elem T) {
+	q.Lock()
+	defer q.Unlock()
+
+	q.growIfFull()
+
+	q.buf[q.tail] = elem
+	// Calculate new tail position.
+	q.tail = q.next(q.tail)
+	q.count++
+}
+
+// PushFront prepends an element to the front of the queue.
+func (q *Deque[T]) PushFront(elem T) {
+	q.Lock()
+	defer q.Unlock()
+
+	q.growIfFull()
+
+	// Calculate new head position.
+	q.head = q.prev(q.head)
+	q.buf[q.head] = elem
+	q.count++
+}
+
+// PopFront removes and returns the element from the front of the queue.
+// Implements FIFO when used with PushBack. If the queue is empty, the call
+// panics.
+func (q *Deque[T]) PopFront() T {
+	q.Lock()
+	defer q.Unlock()
+
+	if q.count <= 0 {
+		panic("deque: PopFront() called on empty queue")
+	}
+	ret := q.buf[q.head]
+	var zero T
+	q.buf[q.head] = zero
+	// Calculate new head position.
+	q.head = q.next(q.head)
+	q.count--
+
+	q.shrinkIfExcess()
+	return ret
+}
+
+// PopBack removes and returns the element from the back of the queue.
+// Implements LIFO when used with PushBack. If the queue is empty, the call
+// panics.
+func (q *Deque[T]) PopBack() T {
+	q.Lock()
+	defer q.Unlock()
+
+	if q.count <= 0 {
+		panic("deque: PopBack() called on empty queue")
+	}
+
+	// Calculate new tail position
+	q.tail = q.prev(q.tail)
+
+	// Remove value at tail.
+	ret := q.buf[q.tail]
+	var zero T
+	q.buf[q.tail] = zero
+	q.count--
+
+	q.shrinkIfExcess()
+	return ret
+}
+
+// Front returns the element at the front of the queue. This is the element
+// that would be returned by PopFront. This call panics if the queue is empty.
+func (q *Deque[T]) Front() T {
+	q.Lock()
+	defer q.Unlock()
+
+	if q.count <= 0 {
+		panic("deque: Front() called when empty")
+	}
+	return q.buf[q.head]
+}
+
+// Back returns the element at the back of the queue. This is the element that
+// would be returned by PopBack. This call panics if the queue is empty.
+func (q *Deque[T]) Back() T {
+	q.Lock()
+	defer q.Unlock()
+
+	if q.count <= 0 {
+		panic("deque: Back() called when empty")
+	}
+	return q.buf[q.prev(q.tail)]
+}
+
+// Clear removes all elements from the queue, but retains the current capacity.
+// This is useful when repeatedly reusing the queue at high frequency to avoid
+// GC during reuse. The queue will not be resized smaller as long as items are
+// only added. Only when items are removed is the queue subject to getting
+// resized smaller.
+func (q *Deque[T]) Clear() {
+	q.Lock()
+	defer q.Unlock()
+
+	var zero T
+	modBits := len(q.buf) - 1
+	h := q.head
+	for i := 0; i < q.Len(); i++ {
+		q.buf[(h+i)&modBits] = zero
+	}
+	q.head = 0
+	q.tail = 0
+	q.count = 0
+}
+
+// prev returns the previous buffer position wrapping around buffer.
+func (q *Deque[T]) prev(i int) int {
+	return (i - 1) & (len(q.buf) - 1) // bitwise modulus
+}
+
+// next returns the next buffer position wrapping around buffer.
+func (q *Deque[T]) next(i int) int {
+	return (i + 1) & (len(q.buf) - 1) // bitwise modulus
+}
+
+// growIfFull resizes up if the buffer is full.
+func (q *Deque[T]) growIfFull() {
+	if q.count != len(q.buf) {
+		return
+	}
+	if len(q.buf) == 0 {
+		if q.minCap == 0 {
+			q.minCap = minCapacity
+		}
+		q.buf = make([]T, q.minCap)
+		return
+	}
+	q.resize(q.count << 1)
+}
+
+// shrinkIfExcess resize down if the buffer 1/4 full.
+func (q *Deque[T]) shrinkIfExcess() {
+	if len(q.buf) > q.minCap && (q.count<<2) == len(q.buf) {
+		q.resize(q.count << 1)
+	}
+}
+
+// resize resizes the deque to fit exactly twice its current contents. This is
+// used to grow the queue when it is full, and also to shrink it when it is
+// only a quarter full.
+func (q *Deque[T]) resize(newSize int) {
+	newBuf := make([]T, newSize)
+	if q.tail > q.head {
+		copy(newBuf, q.buf[q.head:q.tail])
+	} else {
+		n := copy(newBuf, q.buf[q.head:])
+		copy(newBuf[n:], q.buf[:q.tail])
+	}
+
+	q.head = 0
+	q.tail = q.count
+	q.buf = newBuf
+}

--- a/event.go
+++ b/event.go
@@ -1,0 +1,8 @@
+package goedbt
+
+type Observer func(Status)
+
+type Event struct {
+	Behaviour
+	Observer
+}

--- a/export_test.go
+++ b/export_test.go
@@ -1,5 +1,0 @@
-package goedbt
-
-var (
-	Tick = tick
-)

--- a/parallel.go
+++ b/parallel.go
@@ -19,6 +19,7 @@ const (
 // a completed child. Continues to tick any Running children if all completed
 // children have been successful, returning Success if all children succeed.
 type Parallel struct {
+	*BehaviourTree
 	*composite
 
 	// only specify a successPolicy - this implicitly defines the failure
@@ -28,8 +29,9 @@ type Parallel struct {
 	runningNodes []Behaviour
 }
 
-func NewParallel(successPolicy Policy) *Parallel {
+func NewParallel(bt *BehaviourTree, successPolicy Policy) *Parallel {
 	return &Parallel{
+		BehaviourTree: bt,
 		successPolicy: successPolicy,
 		composite: &composite{
 			behaviour: &behaviour{state: Invalid},
@@ -38,11 +40,11 @@ func NewParallel(successPolicy Policy) *Parallel {
 	}
 }
 
-func (n *Parallel) Initialize() {
+func (n *Parallel) initialize() {
 	n.runningNodes = keys(n.children)
 }
 
-func (n *Parallel) Update() Status {
+func (n *Parallel) update() Status {
 	var b Behaviour
 	// track success count and required number of successes for RequireAll
 	// we only need len(runningNodes) successes each tick as we can imply that:
@@ -84,12 +86,12 @@ func (n *Parallel) Update() Status {
 	return n.state
 }
 
-func (n *Parallel) Teardown() {
-	// if this node is configured to Teardown early,
+func (n *Parallel) teardown() {
+	// if this node is configured to teardown early,
 	// abort any running children
 	for c := range n.children {
-		c.Abort()
+		c.teardown()
 	}
 }
 
-func (n *Parallel) Abort() {}
+func (n *Parallel) abort() {}

--- a/parallel.go
+++ b/parallel.go
@@ -32,8 +32,8 @@ func NewParallel(successPolicy Policy) *Parallel {
 	return &Parallel{
 		successPolicy: successPolicy,
 		composite: &composite{
-			node:     &node{state: Invalid},
-			children: make(Set[Behaviour]),
+			behaviour: &behaviour{state: Invalid},
+			children:  make(Set[Behaviour]),
 		},
 	}
 }

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -94,15 +94,13 @@ func TestParallel(t *testing.T) {
 
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
-			tree := setupCompositeTree(
-				goedbt.NewParallel(tc.successPolicy),
-				tc.behaviours...,
-			)
+			parallel := goedbt.NewParallel(tc.successPolicy)
+			tree := setupCompositeTree(parallel, tc.behaviours...)
 
 			for _, s := range tc.expected {
-				status := goedbt.Tick(tree.Root)
-				if status != s {
-					t.Errorf("Selector got %d, want %d", status, s)
+				tree.Tick()
+				if parallel.State() != s {
+					t.Errorf("Selector got %d, want %d", parallel.State(), s)
 				}
 			}
 		})

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -94,8 +94,9 @@ func TestParallel(t *testing.T) {
 
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
-			parallel := goedbt.NewParallel(tc.successPolicy)
-			tree := setupCompositeTree(parallel, tc.behaviours...)
+			tree := goedbt.NewBehaviourTree()
+			parallel := goedbt.NewParallel(tree, tc.successPolicy)
+			setupCompositeTree(tree, parallel, tc.behaviours...)
 
 			for _, s := range tc.expected {
 				tree.Tick()

--- a/selector.go
+++ b/selector.go
@@ -1,6 +1,6 @@
 package goedbt
 
-// Selector defines a Behaviour BehaviourNode that checks each of its children,
+// Selector defines a composite Behaviour that checks each of its children,
 // returning the first non-Failure status or Failure if all children fail
 type Selector struct {
 	*composite

--- a/selector.go
+++ b/selector.go
@@ -3,13 +3,15 @@ package goedbt
 // Selector defines a composite Behaviour that checks each of its children,
 // returning the first non-Failure status or Failure if all children fail
 type Selector struct {
+	*BehaviourTree
 	*composite
 
 	iterator[Behaviour]
 }
 
-func NewSelector() *Selector {
+func NewSelector(bt *BehaviourTree) *Selector {
 	return &Selector{
+		BehaviourTree: bt,
 		composite: &composite{
 			behaviour: &behaviour{state: Invalid},
 			children:  make(Set[Behaviour]),
@@ -17,11 +19,11 @@ func NewSelector() *Selector {
 	}
 }
 
-func (n *Selector) Initialize() {
+func (n *Selector) initialize() {
 	n.iterator = n.Children()
 }
 
-func (n *Selector) Update() Status {
+func (n *Selector) update() Status {
 	for c := range n.seq {
 		status := tick(c)
 		if status != Failure {
@@ -35,5 +37,5 @@ func (n *Selector) Update() Status {
 	return n.state
 }
 
-func (n *Selector) Teardown() {}
-func (n *Selector) Abort()    {}
+func (n *Selector) teardown() {}
+func (n *Selector) abort()    {}

--- a/selector.go
+++ b/selector.go
@@ -11,8 +11,8 @@ type Selector struct {
 func NewSelector() *Selector {
 	return &Selector{
 		composite: &composite{
-			node:     &node{state: Invalid},
-			children: make(Set[Behaviour]),
+			behaviour: &behaviour{state: Invalid},
+			children:  make(Set[Behaviour]),
 		},
 	}
 }

--- a/selector_test.go
+++ b/selector_test.go
@@ -36,12 +36,13 @@ func TestSelector(t *testing.T) {
 
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
-			tree := setupCompositeTree(goedbt.NewSelector(), tc.behaviours...)
+			selector := goedbt.NewSelector()
+			tree := setupCompositeTree(selector, tc.behaviours...)
 
 			for _, s := range tc.expected {
-				status := goedbt.Tick(tree.Root)
-				if status != s {
-					t.Errorf("Selector got %d, want %d", status, s)
+				tree.Tick()
+				if selector.State() != s {
+					t.Errorf("Selector got %d, want %d", selector.State(), s)
 				}
 			}
 		})

--- a/selector_test.go
+++ b/selector_test.go
@@ -36,8 +36,9 @@ func TestSelector(t *testing.T) {
 
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
-			selector := goedbt.NewSelector()
-			tree := setupCompositeTree(selector, tc.behaviours...)
+			tree := goedbt.NewBehaviourTree()
+			selector := goedbt.NewSelector(tree)
+			setupCompositeTree(tree, selector, tc.behaviours...)
 
 			for _, s := range tc.expected {
 				tree.Tick()

--- a/sequencer.go
+++ b/sequencer.go
@@ -3,7 +3,6 @@ package goedbt
 // Sequencer defines a composite Behaviour that checks each of its children,
 // returning the first non-Success status or Success if all children succeed
 type Sequencer struct {
-	*BehaviourTree
 	*composite
 
 	iterator[Behaviour]
@@ -13,8 +12,8 @@ type Sequencer struct {
 // a tree at this point?
 func NewSequencer(bt *BehaviourTree) *Sequencer {
 	return &Sequencer{
-		BehaviourTree: bt,
 		composite: &composite{
+			tree:      bt,
 			behaviour: &behaviour{state: Invalid},
 			children:  make(Set[Behaviour]),
 		},
@@ -23,35 +22,26 @@ func NewSequencer(bt *BehaviourTree) *Sequencer {
 
 func (n *Sequencer) initialize() {
 	n.iterator = n.Children()
-	n.pushCurrentChild()
-}
-
-func (n *Sequencer) pushCurrentChild() {
-	n.Start(&Event{
-		Behaviour: n.current(),
-		Observer:  n.onChildComplete,
-	})
+	n.tree.Start(n.current(), n.onChildComplete)
 }
 
 func (n *Sequencer) onChildComplete(s Status) {
 	c := n.current()
+
 	switch s := c.State(); s {
-	case Failure:
-		n.Stop(&Event{n, nil}, s)
-	case Running:
-		n.pushCurrentChild()
 	case Success:
 		if _, ok := n.next(); !ok {
 			// reached last child, set state to success
-			n.Stop(&Event{n, nil}, s)
+			n.tree.Stop(&Event{n, nil}, s)
 			return
 		}
-		n.pushCurrentChild()
+		n.tree.Start(n.current(), n.onChildComplete)
+	default: // handle failure and aborted cases
+		n.tree.Stop(&Event{n, nil}, Failure)
 	}
 }
 
 func (n *Sequencer) update() Status {
-	n.state = Running
 	return Running
 }
 

--- a/sequencer.go
+++ b/sequencer.go
@@ -1,6 +1,6 @@
 package goedbt
 
-// Sequencer defines a Behaviour BehaviourNode that checks each of its children,
+// Sequencer defines a composite Behaviour that checks each of its children,
 // returning the first non-Success status or Success if all children succeed
 type Sequencer struct {
 	*composite

--- a/sequencer.go
+++ b/sequencer.go
@@ -11,8 +11,8 @@ type Sequencer struct {
 func NewSequencer() *Sequencer {
 	return &Sequencer{
 		composite: &composite{
-			node:     &node{state: Invalid},
-			children: make(Set[Behaviour]),
+			behaviour: &behaviour{state: Invalid},
+			children:  make(Set[Behaviour]),
 		},
 	}
 }

--- a/sequencer_test.go
+++ b/sequencer_test.go
@@ -11,7 +11,7 @@ func setupCompositeTree(t *goedbt.BehaviourTree, c goedbt.Composite, bb ...goedb
 		c.AddChild(b)
 	}
 
-	t.Start(&goedbt.Event{c, nil})
+	t.Start(c, nil)
 }
 
 func TestSequencer(t *testing.T) {

--- a/sequencer_test.go
+++ b/sequencer_test.go
@@ -6,14 +6,12 @@ import (
 	goedbt "github.com/dpsommer/go-edbt"
 )
 
-func setupCompositeTree(c goedbt.Composite, tasks ...goedbt.Behaviour) *goedbt.BehaviourTree {
-	for _, t := range tasks {
-		c.AddChild(t)
+func setupCompositeTree(t *goedbt.BehaviourTree, c goedbt.Composite, bb ...goedbt.Behaviour) {
+	for _, b := range bb {
+		c.AddChild(b)
 	}
 
-	tree := goedbt.NewBehaviourTree()
-	tree.Start(c)
-	return tree
+	t.Start(&goedbt.Event{c, nil})
 }
 
 func TestSequencer(t *testing.T) {
@@ -45,8 +43,9 @@ func TestSequencer(t *testing.T) {
 
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
-			sequencer := goedbt.NewSequencer()
-			tree := setupCompositeTree(sequencer, tc.behaviours...)
+			tree := goedbt.NewBehaviourTree()
+			sequencer := goedbt.NewSequencer(tree)
+			setupCompositeTree(tree, sequencer, tc.behaviours...)
 
 			for _, s := range tc.expected {
 				tree.Tick()

--- a/sequencer_test.go
+++ b/sequencer_test.go
@@ -11,7 +11,9 @@ func setupCompositeTree(c goedbt.Composite, tasks ...goedbt.Behaviour) *goedbt.B
 		c.AddChild(t)
 	}
 
-	return goedbt.NewBehaviourTree(c)
+	tree := goedbt.NewBehaviourTree()
+	tree.Start(c)
+	return tree
 }
 
 func TestSequencer(t *testing.T) {
@@ -43,12 +45,13 @@ func TestSequencer(t *testing.T) {
 
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
-			tree := setupCompositeTree(goedbt.NewSequencer(), tc.behaviours...)
+			sequencer := goedbt.NewSequencer()
+			tree := setupCompositeTree(sequencer, tc.behaviours...)
 
 			for _, s := range tc.expected {
-				status := goedbt.Tick(tree.Root)
-				if status != s {
-					t.Errorf("Selector got %d, want %d", status, s)
+				tree.Tick()
+				if sequencer.State() != s {
+					t.Errorf("Selector got %d, want %d", sequencer.State(), s)
 				}
 			}
 		})

--- a/tree.go
+++ b/tree.go
@@ -2,19 +2,49 @@ package goedbt
 
 type BehaviourTree struct {
 	blackboard map[string]any
-	Root       Behaviour
+	scheduler  *Deque[Behaviour]
 }
 
-func NewBehaviourTree(b Behaviour) *BehaviourTree {
+func NewBehaviourTree() *BehaviourTree {
 	return &BehaviourTree{
 		blackboard: map[string]any{},
-		Root:       b,
+		scheduler:  NewDeque[Behaviour](minCapacity),
 	}
 }
 
-func (t *BehaviourTree) Start() {
-	for {
-		// XXX: just ignore the status for now
-		tick(t.Root)
+func (t *BehaviourTree) Tick() {
+	// demarcate the end of the current tick schedule with a nil value
+	t.scheduler.PushBack(nil)
+	for t.step() {
+		// continue until we reach the nil value
 	}
+}
+
+func (t *BehaviourTree) step() bool {
+	b := t.scheduler.PopFront()
+	if b == nil {
+		return false
+	}
+
+	state := tick(b)
+	if state != Running {
+		b.FireObserver(state)
+	} else {
+		t.scheduler.PushBack(b)
+	}
+
+	return true
+}
+
+func (t *BehaviourTree) Start(b Behaviour) {
+	t.scheduler.PushFront(b)
+}
+
+func (t *BehaviourTree) Stop(b Behaviour, s Status) {
+	if s == Running {
+		panic("can't set Running state for stopped behaviour")
+	}
+
+	b.SetState(s)
+	b.FireObserver(s)
 }

--- a/tree.go
+++ b/tree.go
@@ -1,5 +1,7 @@
 package goedbt
 
+type Search func(*Event) bool
+
 type BehaviourTree struct {
 	blackboard map[string]any
 	scheduler  *deque[*Event]
@@ -36,8 +38,8 @@ func (t *BehaviourTree) step() bool {
 	return true
 }
 
-func (t *BehaviourTree) Start(e *Event) {
-	t.scheduler.PushFront(e)
+func (t *BehaviourTree) Start(b Behaviour, o Observer) {
+	t.scheduler.PushFront(&Event{Behaviour: b, Observer: o})
 }
 
 func (t *BehaviourTree) Stop(e *Event, s Status) {
@@ -49,4 +51,9 @@ func (t *BehaviourTree) Stop(e *Event, s Status) {
 	if e.Observer != nil {
 		e.Observer(s)
 	}
+}
+
+func (t *BehaviourTree) Abort(b Behaviour, s Search) {
+	b.abort()
+	t.scheduler.Remove(t.scheduler.RIndex(s))
 }

--- a/utils.go
+++ b/utils.go
@@ -2,9 +2,38 @@ package goedbt
 
 import "iter"
 
+type next[T any] func() (T, bool)
+
+type current[T any] func() T
+
 type iterator[T any] struct {
 	seq iter.Seq[T]
-	next
+	current[T]
+	next[T]
+}
+
+func newIterator[T any](tt []T) iterator[T] {
+	var i int
+
+	// return an iterator and a closure that increments the iterator so that we
+	// can resume iteration from the same key if a child is running
+	return iterator[T]{
+		seq: func(yield func(T) bool) {
+			for j := 0; j < len(tt); j += 1 {
+				if !yield(tt[j]) {
+					return
+				}
+			}
+		},
+		current: func() T { return tt[i] },
+		next: func() (T, bool) {
+			if i+1 >= len(tt) {
+				return *new(T), false
+			}
+			i += 1
+			return tt[i], true
+		},
+	}
 }
 
 type Set[K comparable] map[K]struct{}

--- a/utils.go
+++ b/utils.go
@@ -49,7 +49,3 @@ func keys[K comparable, T any](m map[K]T) []K {
 
 	return keys
 }
-
-func pop[T any](s []T) (T, []T) {
-	return s[len(s)-1], s[:len(s)-1]
-}


### PR DESCRIPTION
Update BehaviourTree and composite nodes to use event-driven logic.

Adds a deque "scheduler" to the tree, which nodes push to as they are ticked. Each tree tick pushes a marker to the back of the queue and pops from the front until the marker is reached, ticking each node in sequence. Running nodes are pushed to the back of the queue to be checked again on the next tick.

The deque implementation is a modified copy of https://github.com/gammazero/deque with some additional error handling and a simple mutex lock.